### PR TITLE
Fixed typo in appsettings.json

### DIFF
--- a/OpenTibia.Server.Standalone/appsettings.json
+++ b/OpenTibia.Server.Standalone/appsettings.json
@@ -4,7 +4,7 @@
     "OriginalMapDirectory": "originalMap"
   },
   "MonFilesMonsterTypeLoaderOptions": {
-    "MonsterFilesDirectory": "monters"
+    "MonsterFilesDirectory": "monsters"
   },
   "MonsterDbFileMonsterSpawnLoaderOptions": {
     "FilePath": "config/monster.db"


### PR DESCRIPTION
Fixed typo in appsettings.json
'monters' on line 7 should have been 'monsters'.