### PR TITLE
Fix a bug in which the PlayerInventory destructor caused a crash

### DIFF
--- a/OpenTibia.Server/PlayerInventory.cs
+++ b/OpenTibia.Server/PlayerInventory.cs
@@ -51,6 +51,11 @@ namespace OpenTibia.Server
         {
             foreach (Slot slot in Enum.GetValues(typeof(Slot)).Cast<Slot>())
             {
+                if (slot >= Slot.Anywhere)
+                {
+                    continue;
+                }
+
                 this.inventory[slot].ParentCylinder = null;
 
                 this.inventory[slot].OnContentAdded -= this.HandleContentAdded;


### PR DESCRIPTION
## Problem:
When the destructor iterated over slots, it did so without disregarding slots without bodyContainers, resulting in a null pointer exception which was unhandled since this ran under the GC thread.

## Solution:
Exclude slots without the items in the destruction.