### PR TITLE
small fix to hit points message package send only to the target player.

### DIFF
--- a/src/Fibula.Mechanics/Operations/BasicAttackOperation.cs
+++ b/src/Fibula.Mechanics/Operations/BasicAttackOperation.cs
@@ -179,7 +179,7 @@ namespace Fibula.Mechanics.Operations
                 {
                     damageTextColor = TextColor.LightBlue;
                 }
-                else if (this.Target is IPlayer)
+                else if (this.Target is IPlayer playerTarget)
                 {
                     var hitpointsLostMessage = $"You lose {damageDoneInfo.Damage} hitpoints";
 
@@ -192,7 +192,8 @@ namespace Fibula.Mechanics.Operations
 
                     hitpointsLostMessage += ".";
 
-                    packetsToSend.Add(new TextMessagePacket(MessageType.StatusDefault, hitpointsLostMessage));
+                    var hitpointsLostPacket = new TextMessagePacket(MessageType.StatusDefault, hitpointsLostMessage);
+                    this.SendNotification(context, new GenericNotification(() => playerTarget.YieldSingleItem(), hitpointsLostPacket));
                 }
 
                 packetsToSend.Add(new AnimatedTextPacket(this.Target.Location, damageTextColor, Math.Abs(damageDoneInfo.Damage).ToString()));


### PR DESCRIPTION
I detected that the message stating that the player lost life points is being sent to all players visible on the map, this small correction causes it to be sent only to the player who actually suffered the damage.